### PR TITLE
Fix CMS backend configuration

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,11 +1,6 @@
 backend:
-  name: auth0
-  repo: ethanbaileyhomework/website-food-truck
+  name: git-gateway
   branch: main
-  auth0:
-    # The Auth0 credentials are injected at runtime by the admin config API route.
-    client_id: ""
-    auth_domain: ""
 
 media_folder: "public/uploads"
 public_folder: "/uploads"

--- a/app/api/admin/config/route.ts
+++ b/app/api/admin/config/route.ts
@@ -7,57 +7,16 @@ export const dynamic = "force-dynamic";
 
 const CONFIG_TEMPLATE_PATH = path.join(process.cwd(), "admin", "config.yml");
 
-type PlainObject = Record<string, unknown>;
-
-function resolveAuth0Setting(name: string) {
-  return (
-    process.env[name] ??
-    process.env[`NEXT_PUBLIC_${name}`] ??
-    ""
-  );
-}
-
-function getAuth0Settings() {
-  const domain = resolveAuth0Setting("AUTH0_DOMAIN");
-  const clientId = resolveAuth0Setting("AUTH0_CLIENT_ID");
-  return { domain, clientId };
-}
-
 export async function GET() {
   try {
-    const { domain, clientId } = getAuth0Settings();
-
-    if (!domain || !clientId) {
-      console.error(
-        "CMS configuration requires AUTH0_DOMAIN and AUTH0_CLIENT_ID environment variables."
-      );
-      return NextResponse.json(
-        {
-          message:
-            "Content manager configuration error. Missing Auth0 credentials.",
-        },
-        { status: 500 }
-      );
-    }
-
     const raw = await readFile(CONFIG_TEMPLATE_PATH, "utf8");
-    const parsed = YAML.parse(raw) as PlainObject | null;
+    const parsed = YAML.parse(raw);
 
     if (!parsed || typeof parsed !== "object") {
       throw new Error("Invalid CMS configuration template.");
     }
 
-    const backend = (parsed.backend as PlainObject | undefined) ?? {};
-    const auth0 = (backend.auth0 as PlainObject | undefined) ?? {};
-
-    auth0.client_id = clientId;
-    auth0.auth_domain = domain;
-    auth0.domain = domain;
-
-    backend.auth0 = auth0;
-    parsed.backend = backend;
-
-    return NextResponse.json(parsed, {
+    return NextResponse.json(parsed as Record<string, unknown>, {
       headers: { "cache-control": "no-store" },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- update the Decap CMS template to use the built-in git-gateway backend
- simplify the admin config API route to return the YAML template without Auth0 injection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0c9596f7c8331840edc6ae930b9ac