### PR TITLE
Redirect Netlify Identity invite confirmations to admin

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 import { Analytics } from "@/components/layout/analytics";
+import { IdentityRedirect } from "@/components/layout/identity-redirect";
 import { Footer } from "@/components/layout/footer";
 import { Header } from "@/components/layout/header";
 import { StructuredData } from "@/components/layout/structured-data";
@@ -58,6 +59,7 @@ export default async function RootLayout({
       </head>
       <body className="min-h-screen bg-sand text-charcoal">
         <Header siteName={settings.siteName} />
+        <IdentityRedirect />
         <main className="px-4 pb-16 pt-8 sm:px-6 lg:px-8">{children}</main>
         <Footer settings={settings} />
         <Analytics measurementId={settings.analytics?.gaMeasurementId} />

--- a/components/layout/identity-redirect.tsx
+++ b/components/layout/identity-redirect.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+const IDENTITY_HASH_PARAMS = [
+  "invite_token",
+  "confirmation_token",
+  "recovery_token",
+  "access_token",
+];
+
+function shouldRedirect(hash: string | undefined | null) {
+  if (!hash || hash.length <= 1) {
+    return false;
+  }
+
+  const params = new URLSearchParams(hash.replace(/^#/, ""));
+
+  return IDENTITY_HASH_PARAMS.some((param) => params.has(param));
+}
+
+export function IdentityRedirect() {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const { hash, pathname } = window.location;
+
+    if (pathname.startsWith("/admin")) {
+      return;
+    }
+
+    if (shouldRedirect(hash)) {
+      window.location.replace(`/admin/${hash}`);
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a client-side IdentityRedirect helper that detects Netlify Identity invite tokens
- use the helper in the root layout so invite confirmations jump straight to /admin

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d12ffdbe5483319419f4c848960c56