### PR TITLE
Fix Netlify CMS admin route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/admin",
+        destination: "/admin/index.html",
+        permanent: false,
+      },
+    ];
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add a Next.js redirect so requests to `/admin` are served from `/admin/index.html`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d13b00c1d083319551fa6c16c20671