### PR TITLE
feat: expand CMS control for site content

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -24,6 +24,20 @@ collections:
           - { label: "Tagline", name: "siteTagline", widget: "string", required: false }
           - { label: "Logo", name: "logo", widget: "image", required: false }
           - { label: "Primary Color", name: "primaryColor", widget: "color", default: "#C3423F" }
+          - label: "Navigation"
+            name: "navigation"
+            widget: "list"
+            required: false
+            fields:
+              - { label: "Label", name: "label", widget: "string" }
+              - { label: "Link", name: "href", widget: "string" }
+              - label: "Style"
+                name: "variant"
+                widget: "select"
+                required: false
+                options:
+                  - { label: "Link", value: "link" }
+                  - { label: "Button", value: "button" }
           - label: "Contact"
             name: "contact"
             widget: "object"
@@ -57,6 +71,36 @@ collections:
               - { label: "PayPal Donate URL", name: "paypal", widget: "string", required: false }
               - { label: "Stripe Checkout URL", name: "stripe", widget: "string", required: false }
               - { label: "Donation Note", name: "note", widget: "text", required: false }
+          - label: "Donation Copy"
+            name: "donationCopy"
+            widget: "object"
+            required: false
+            fields:
+              - label: "Bank Section"
+                name: "bankSection"
+                widget: "object"
+                required: false
+                fields:
+                  - { label: "Eyebrow", name: "eyebrow", widget: "string", required: false }
+                  - { label: "Title", name: "title", widget: "string", required: false }
+                  - label: "Field Labels"
+                    name: "fieldLabels"
+                    widget: "object"
+                    required: false
+                    fields:
+                      - { label: "Account Name", name: "accountName", widget: "string", required: false }
+                      - { label: "BSB", name: "bsb", widget: "string", required: false }
+                      - { label: "Account Number", name: "accountNumber", widget: "string", required: false }
+                      - { label: "Reference", name: "reference", widget: "string", required: false }
+              - label: "Online Section"
+                name: "onlineSection"
+                widget: "object"
+                required: false
+                fields:
+                  - { label: "Eyebrow", name: "eyebrow", widget: "string", required: false }
+                  - { label: "Title", name: "title", widget: "string", required: false }
+                  - { label: "PayPal Button Label", name: "paypalLabel", widget: "string", required: false }
+                  - { label: "Stripe Button Label", name: "stripeLabel", widget: "string", required: false }
           - label: "Map"
             name: "map"
             widget: "object"
@@ -79,6 +123,17 @@ collections:
                 widget: "list"
                 field: { label: "Note", name: "note", widget: "string" }
               - { label: "Directions Button Label", name: "ctaLabel", widget: "string", required: false }
+              - label: "Labels"
+                name: "labels"
+                widget: "object"
+                required: false
+                fields:
+                  - { label: "Hero Card Eyebrow", name: "heroEyebrow", widget: "string", required: false }
+                  - { label: "Section Eyebrow", name: "sectionEyebrow", widget: "string", required: false }
+                  - { label: "Notes Title", name: "notesTitle", widget: "string", required: false }
+                  - { label: "Call Button Label", name: "callCta", widget: "string", required: false }
+                  - { label: "Email Button Label", name: "emailCta", widget: "string", required: false }
+                  - { label: "Map Title", name: "mapTitle", widget: "string", required: false }
           - label: "Looker Studio"
             name: "lookers"
             widget: "object"
@@ -86,6 +141,30 @@ collections:
               - { label: "Dashboard URL", name: "statsUrl", widget: "string", required: false }
               - { label: "Embed Title", name: "embedTitle", widget: "string", required: false }
           - { label: "Tally Form URL", name: "tallyFormUrl", widget: "string", required: false }
+          - label: "Volunteer Form"
+            name: "volunteerForm"
+            widget: "object"
+            required: false
+            fields:
+              - { label: "Placeholder Title", name: "placeholderTitle", widget: "string", required: false }
+              - { label: "Placeholder Body", name: "placeholderBody", widget: "text", required: false }
+              - { label: "Iframe Title", name: "iframeTitle", widget: "string", required: false }
+          - label: "Footer"
+            name: "footer"
+            widget: "object"
+            required: false
+            fields:
+              - { label: "Contact Heading", name: "contactHeading", widget: "string", required: false }
+              - { label: "Contact Body", name: "contactBody", widget: "text", required: false }
+              - { label: "Social Heading", name: "socialHeading", widget: "string", required: false }
+              - { label: "Bottom Note", name: "bottomNote", widget: "string", required: false }
+              - label: "Footer Links"
+                name: "links"
+                widget: "list"
+                required: false
+                fields:
+                  - { label: "Label", name: "label", widget: "string" }
+                  - { label: "Link", name: "href", widget: "string" }
           - label: "Analytics"
             name: "analytics"
             widget: "object"
@@ -114,6 +193,7 @@ collections:
               - { label: "Headline", name: "headline", widget: "string" }
               - { label: "Subheadline", name: "subheadline", widget: "text", required: false }
               - { label: "Hero Image", name: "image", widget: "image", required: false }
+              - { label: "Hero Image Alt Text", name: "imageAlt", widget: "string", required: false }
               - label: "CTAs"
                 name: "ctas"
                 widget: "object"
@@ -214,6 +294,52 @@ collections:
               - { label: "Volunteers", name: "volunteers", widget: "number" }
               - { label: "Groceries", name: "groceries", widget: "number" }
               - { label: "Notes", name: "notes", widget: "text", required: false }
+          - label: "Page Copy"
+            name: "page"
+            widget: "object"
+            required: false
+            fields:
+              - { label: "Heading", name: "heading", widget: "string", required: false }
+              - { label: "Intro", name: "intro", widget: "text", required: false }
+          - label: "Latest Service Section"
+            name: "latestSection"
+            widget: "object"
+            required: false
+            fields:
+              - { label: "Eyebrow", name: "eyebrow", widget: "string", required: false }
+              - { label: "Screen Reader Label", name: "srLabel", widget: "string", required: false }
+              - { label: "Streaming Message", name: "streamingMessage", widget: "text", required: false }
+              - { label: "Fallback Message", name: "fallbackMessage", widget: "text", required: false }
+              - label: "Metric Labels"
+                name: "metrics"
+                widget: "object"
+                required: false
+                fields:
+                  - { label: "Meals", name: "meals", widget: "string", required: false }
+                  - { label: "Guests", name: "guests", widget: "string", required: false }
+                  - { label: "Volunteers", name: "volunteers", widget: "string", required: false }
+                  - { label: "Groceries", name: "groceries", widget: "string", required: false }
+          - label: "Totals Section"
+            name: "totalsSection"
+            widget: "object"
+            required: false
+            fields:
+              - label: "Metric Labels"
+                name: "metrics"
+                widget: "object"
+                required: false
+                fields:
+                  - { label: "Meals", name: "meals", widget: "string", required: false }
+                  - { label: "Guests", name: "guests", widget: "string", required: false }
+                  - { label: "Volunteers", name: "volunteers", widget: "string", required: false }
+                  - { label: "Services", name: "services", widget: "string", required: false }
+          - label: "Dashboard Section"
+            name: "dashboardSection"
+            widget: "object"
+            required: false
+            fields:
+              - { label: "Title", name: "title", widget: "string", required: false }
+              - { label: "Description", name: "description", widget: "text", required: false }
           - label: "Looker Studio"
             name: "lookers"
             widget: "object"
@@ -374,4 +500,23 @@ collections:
       - { label: "Logo", name: "logo", widget: "image", required: false }
       - { label: "Blurb", name: "blurb", widget: "markdown", required: false }
       - { label: "Category", name: "category", widget: "select", options: ["sponsor", "partner"], required: false }
+  - name: "legal"
+    label: "Legal Pages"
+    editor:
+      preview: false
+    files:
+      - label: "Privacy Policy"
+        name: "privacy"
+        file: "content/legal/privacy.md"
+        fields:
+          - { label: "Title", name: "title", widget: "string" }
+          - { label: "Description", name: "description", widget: "string", required: false }
+          - { label: "Body", name: "body", widget: "markdown" }
+      - label: "Terms of Use"
+        name: "terms"
+        file: "content/legal/terms.md"
+        fields:
+          - { label: "Title", name: "title", widget: "string" }
+          - { label: "Description", name: "description", widget: "string", required: false }
+          - { label: "Body", name: "body", widget: "markdown" }
       - { label: "Display Order", name: "order", widget: "number", required: false }

--- a/app/donate/page.tsx
+++ b/app/donate/page.tsx
@@ -21,7 +21,7 @@ export default async function DonatePage() {
         <h1 className="text-4xl font-semibold text-charcoal sm:text-5xl">{donate.introTitle}</h1>
         <MarkdownRenderer content={donate.introBody} />
       </header>
-      <DonateBox bank={settings.bank} donate={settings.donate} />
+      <DonateBox bank={settings.bank} donate={settings.donate} copy={settings.donationCopy} />
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default async function RootLayout({
         <StructuredData settings={settings} />
       </head>
       <body className="min-h-screen bg-sand text-charcoal">
-        <Header siteName={settings.siteName} />
+        <Header settings={settings} />
         <IdentityRedirect />
         <main className="px-4 pb-16 pt-8 sm:px-6 lg:px-8">{children}</main>
         <Footer settings={settings} />

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,18 +1,23 @@
-export const metadata = {
-  title: "Privacy",
-  description: "Privacy statement placeholder for Cranbourne Food Truck.",
-};
+import type { Metadata } from "next";
 
-export default function PrivacyPage() {
+import { MarkdownRenderer } from "@/components/shared/markdown-renderer";
+import { getLegalPage } from "@/lib/content";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const page = await getLegalPage("privacy");
+  return {
+    title: page.title,
+    description: page.description,
+  };
+}
+
+export default async function PrivacyPage() {
+  const page = await getLegalPage("privacy");
+
   return (
     <div className="mx-auto max-w-3xl space-y-6">
-      <h1 className="text-4xl font-semibold text-charcoal">Privacy statement</h1>
-      <p className="text-base text-charcoal/75">
-        This is a placeholder privacy statement. Update this page through the CMS or by editing app/privacy/page.tsx with your organisation’s privacy policy.
-      </p>
-      <p className="text-base text-charcoal/75">
-        For questions please email <a className="text-brand-primary" href="mailto:hello@cranbournefoodtruck.com">hello@cranbournefoodtruck.com</a>.
-      </p>
+      <h1 className="text-4xl font-semibold text-charcoal">{page.title}</h1>
+      <MarkdownRenderer content={page.body} />
     </div>
   );
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -15,19 +15,18 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function StatsPage() {
   const [stats, site] = await Promise.all([getStatsSettings(), getSiteSettings()]);
 
+  const heading = stats.page?.heading ?? "Service stats";
+  const intro = stats.page?.intro ??
+    "Live counts of meals, guests and volunteers powered by our Google Sheet. Explore deeper trends via the interactive dashboard below.";
+
   return (
     <div className="mx-auto max-w-6xl space-y-12">
       <header className="space-y-4 text-center">
-        <h1 className="text-4xl font-semibold text-charcoal sm:text-5xl">Service stats</h1>
-        <p className="mx-auto max-w-2xl text-base text-charcoal/75">
-          Live counts of meals, guests and volunteers powered by our Google Sheet. Explore deeper trends via the interactive dashboard below.
-        </p>
+        <h1 className="text-4xl font-semibold text-charcoal sm:text-5xl">{heading}</h1>
+        {intro && <p className="mx-auto max-w-2xl text-base text-charcoal/75">{intro}</p>}
       </header>
-      <KPIBar
-        fallbackTotals={stats.fallbackTotals}
-        fallbackLatestService={stats.fallbackLatestService}
-      />
-      <LookerEmbed looker={stats.lookers ?? site.lookers} />
+      <KPIBar stats={stats} />
+      <LookerEmbed looker={stats.lookers ?? site.lookers} dashboard={stats.dashboardSection} />
     </div>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,18 +1,23 @@
-export const metadata = {
-  title: "Terms",
-  description: "Terms of use placeholder for Cranbourne Food Truck.",
-};
+import type { Metadata } from "next";
 
-export default function TermsPage() {
+import { MarkdownRenderer } from "@/components/shared/markdown-renderer";
+import { getLegalPage } from "@/lib/content";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const page = await getLegalPage("terms");
+  return {
+    title: page.title,
+    description: page.description,
+  };
+}
+
+export default async function TermsPage() {
+  const page = await getLegalPage("terms");
+
   return (
     <div className="mx-auto max-w-3xl space-y-6">
-      <h1 className="text-4xl font-semibold text-charcoal">Terms of use</h1>
-      <p className="text-base text-charcoal/75">
-        This is a placeholder terms of use page. Provide your service terms through the CMS or by editing app/terms/page.tsx with the appropriate information.
-      </p>
-      <p className="text-base text-charcoal/75">
-        Contact us at <a className="text-brand-primary" href="mailto:hello@cranbournefoodtruck.com">hello@cranbournefoodtruck.com</a> with any questions.
-      </p>
+      <h1 className="text-4xl font-semibold text-charcoal">{page.title}</h1>
+      <MarkdownRenderer content={page.body} />
     </div>
   );
 }

--- a/app/volunteer/page.tsx
+++ b/app/volunteer/page.tsx
@@ -21,7 +21,7 @@ export default async function VolunteerPage() {
         <h1 className="text-4xl font-semibold text-charcoal sm:text-5xl">{volunteer.introTitle}</h1>
         <MarkdownRenderer content={volunteer.introBody} />
       </header>
-      <TallyEmbed tallyUrl={settings.tallyFormUrl} />
+      <TallyEmbed tallyUrl={settings.tallyFormUrl} form={settings.volunteerForm} />
     </div>
   );
 }

--- a/components/donate/donate-box.tsx
+++ b/components/donate/donate-box.tsx
@@ -1,40 +1,56 @@
 import Link from "next/link";
 
-import type { BankDetails, DonateLinks } from "@/lib/types";
+import type { BankDetails, DonateLinks, DonationCopy } from "@/lib/types";
 
-export function DonateBox({ bank, donate }: { bank?: BankDetails; donate?: DonateLinks }) {
+export function DonateBox({
+  bank,
+  donate,
+  copy,
+}: {
+  bank?: BankDetails;
+  donate?: DonateLinks;
+  copy?: DonationCopy;
+}) {
   if (!bank && !donate) return null;
+
+  const bankSection = copy?.bankSection ?? {};
+  const bankFieldLabels = bankSection.fieldLabels ?? {};
+  const onlineSection = copy?.onlineSection ?? {};
 
   return (
     <section className="mx-auto mt-12 max-w-5xl rounded-3xl bg-white p-8 shadow-soft sm:p-12">
       <div className="grid gap-10 lg:grid-cols-2">
         <div className="space-y-6">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/70">Direct deposit</p>
-            <h3 className="mt-2 text-2xl font-semibold text-charcoal">Bank transfer details</h3>
+            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/70">
+              {bankSection.eyebrow ?? "Direct deposit"}
+            </p>
+            <h3 className="mt-2 text-2xl font-semibold text-charcoal">
+              {bankSection.title ?? "Bank transfer details"}
+            </h3>
           </div>
           <dl className="space-y-3 text-sm">
             {bank?.accountName && (
               <div>
-                <dt className="font-semibold text-charcoal/90">Account name</dt>
+                <dt className="font-semibold text-charcoal/90">{bankFieldLabels.accountName ?? "Account name"}</dt>
                 <dd className="text-charcoal/80">{bank.accountName}</dd>
               </div>
             )}
             {bank?.bsb && (
               <div>
-                <dt className="font-semibold text-charcoal/90">BSB</dt>
+                <dt className="font-semibold text-charcoal/90">{bankFieldLabels.bsb ?? "BSB"}</dt>
                 <dd className="text-charcoal/80">{bank.bsb}</dd>
               </div>
             )}
             {bank?.accountNumber && (
               <div>
-                <dt className="font-semibold text-charcoal/90">Account number</dt>
+                <dt className="font-semibold text-charcoal/90">{bankFieldLabels.accountNumber ?? "Account number"}</dt>
                 <dd className="text-charcoal/80">{bank.accountNumber}</dd>
               </div>
             )}
             {bank?.reference && (
               <div>
-                <dt className="font-semibold text-charcoal/90">Reference</dt>
+                <dt className="font-semibold text-charcoal/90">{bankFieldLabels.reference ?? "Reference"}</dt>
                 <dd className="text-charcoal/80">{bank.reference}</dd>
               </div>
             )}
@@ -42,8 +58,12 @@ export function DonateBox({ bank, donate }: { bank?: BankDetails; donate?: Donat
         </div>
         <div className="space-y-6">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/70">Give online</p>
-            <h3 className="mt-2 text-2xl font-semibold text-charcoal">Secure donate links</h3>
+            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/70">
+              {onlineSection.eyebrow ?? "Give online"}
+            </p>
+            <h3 className="mt-2 text-2xl font-semibold text-charcoal">
+              {onlineSection.title ?? "Secure donate links"}
+            </h3>
           </div>
           <div className="flex flex-col gap-3">
             {donate?.paypal && (
@@ -51,7 +71,7 @@ export function DonateBox({ bank, donate }: { bank?: BankDetails; donate?: Donat
                 href={donate.paypal}
                 className="inline-flex items-center justify-center rounded-full bg-brand-primary px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
               >
-                Donate via PayPal
+                {onlineSection.paypalLabel ?? "Donate via PayPal"}
               </Link>
             )}
             {donate?.stripe && (
@@ -59,7 +79,7 @@ export function DonateBox({ bank, donate }: { bank?: BankDetails; donate?: Donat
                 href={donate.stripe}
                 className="inline-flex items-center justify-center rounded-full border border-brand-primary/40 px-6 py-3 text-sm font-semibold text-brand-primary transition hover:border-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
               >
-                Donate via Stripe
+                {onlineSection.stripeLabel ?? "Donate via Stripe"}
               </Link>
             )}
           </div>

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -32,7 +32,9 @@ export function Hero({ hero, service }: { hero: HomeHero; service?: ServiceDetai
           {service && (
             <div className="grid gap-3 rounded-2xl bg-white/80 p-5 shadow-soft backdrop-blur">
               <div>
-                <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/80">This week’s service</p>
+                <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/80">
+                  {service.labels?.heroEyebrow ?? "This week’s service"}
+                </p>
                 <p className="text-lg font-semibold text-charcoal">{service.title}</p>
               </div>
               <dl className="grid gap-2 text-sm text-charcoal/85 sm:grid-cols-2">
@@ -67,7 +69,7 @@ export function Hero({ hero, service }: { hero: HomeHero; service?: ServiceDetai
             <div className="relative aspect-[4/3] w-full max-w-xl">
               <Image
                 src={hero.image}
-                alt="Community members gathered at the Cranbourne Food Truck"
+                alt={hero.imageAlt ?? hero.headline}
                 fill
                 className="rounded-3xl object-cover shadow-soft"
                 priority

--- a/components/home/service-info.tsx
+++ b/components/home/service-info.tsx
@@ -5,12 +5,16 @@ import type { ServiceDetails, SiteSettings } from "@/lib/types";
 export function ServiceInfo({ service, map }: { service?: ServiceDetails; map?: SiteSettings["map"] }) {
   if (!service) return null;
 
+  const labels = service.labels ?? {};
+
   return (
     <section id="service-details" className="mx-auto mt-16 max-w-6xl rounded-3xl bg-white p-8 shadow-soft sm:p-12">
       <div className="grid gap-10 lg:grid-cols-[1.2fr,1fr]">
         <div className="space-y-6">
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/75">Service details</p>
+            <p className="text-sm font-semibold uppercase tracking-wide text-brand-primary/75">
+              {labels.sectionEyebrow ?? "Service details"}
+            </p>
             <h2 className="mt-2 text-3xl font-semibold text-charcoal">{service.title ?? "Weekly service"}</h2>
             {service.description && <p className="mt-3 text-base text-charcoal/80">{service.description}</p>}
           </div>
@@ -36,7 +40,7 @@ export function ServiceInfo({ service, map }: { service?: ServiceDetails; map?: 
           </dl>
           {service.notes && service.notes.length > 0 && (
             <div className="rounded-2xl bg-sand/70 p-4 text-sm text-charcoal/80">
-              <p className="font-semibold text-charcoal">What to expect</p>
+              <p className="font-semibold text-charcoal">{labels.notesTitle ?? "What to expect"}</p>
               <ul className="mt-2 list-disc space-y-1 pl-5">
                 {service.notes.map((note) => (
                   <li key={note}>{note}</li>
@@ -50,7 +54,7 @@ export function ServiceInfo({ service, map }: { service?: ServiceDetails; map?: 
                 href={`tel:${service.phone}`}
                 className="inline-flex items-center justify-center rounded-full bg-brand-primary px-5 py-2.5 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
               >
-                Call us
+                {labels.callCta ?? "Call us"}
               </Link>
             )}
             {service.email && (
@@ -58,7 +62,7 @@ export function ServiceInfo({ service, map }: { service?: ServiceDetails; map?: 
                 href={`mailto:${service.email}`}
                 className="inline-flex items-center justify-center rounded-full border border-brand-primary/40 px-5 py-2.5 text-sm font-semibold text-brand-primary transition hover:border-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
               >
-                Email the team
+                {labels.emailCta ?? "Email the team"}
               </Link>
             )}
             {map?.directionsUrl && (
@@ -74,7 +78,7 @@ export function ServiceInfo({ service, map }: { service?: ServiceDetails; map?: 
         {map?.embedUrl && (
           <div className="overflow-hidden rounded-2xl shadow-soft">
             <iframe
-              title="Service location map"
+              title={labels.mapTitle ?? "Service location map"}
               src={map.embedUrl}
               className="h-[320px] w-full border-0"
               loading="lazy"

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import type { SiteSettings } from "@/lib/types";
+import type { FooterLink, SiteSettings } from "@/lib/types";
 import { ensureHttps } from "@/lib/utils";
 
 const socialLabels: Record<string, string> = {
@@ -14,15 +14,26 @@ const socialLabels: Record<string, string> = {
 
 export function Footer({ settings }: { settings: SiteSettings }) {
   const { contact, socials } = settings;
+  const footerCopy = settings.footer ?? {};
+  const contactHeading = footerCopy.contactHeading ?? "Stay connected";
+  const contactBody =
+    footerCopy.contactBody ?? settings.siteTagline ?? "We’re here to serve our Cranbourne neighbours with warmth and dignity.";
+  const socialHeading = footerCopy.socialHeading ?? "Follow our journey";
+  const footerLinks: FooterLink[] =
+    footerCopy.links && footerCopy.links.length > 0
+      ? footerCopy.links
+      : [
+          { label: "Privacy", href: "/privacy" },
+          { label: "Terms", href: "/terms" },
+        ];
+  const bottomNote = footerCopy.bottomNote ?? "Built with care for the Cranbourne community.";
 
   return (
     <footer className="mt-16 border-t border-white/60 bg-white">
       <div className="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:px-6 md:grid-cols-2 lg:px-8">
         <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-charcoal">Stay connected</h2>
-          <p className="max-w-lg text-sm text-charcoal/80">
-            {settings.siteTagline ?? "We’re here to serve our Cranbourne neighbours with warmth and dignity."}
-          </p>
+          <h2 className="text-xl font-semibold text-charcoal">{contactHeading}</h2>
+          {contactBody && <p className="max-w-lg text-sm text-charcoal/80">{contactBody}</p>}
           <div className="space-y-2 text-sm">
             {contact?.email && (
               <p>
@@ -53,7 +64,7 @@ export function Footer({ settings }: { settings: SiteSettings }) {
           </div>
         </div>
         <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-charcoal">Follow our journey</h2>
+          <h2 className="text-xl font-semibold text-charcoal">{socialHeading}</h2>
           <div className="flex flex-wrap gap-3">
             {socials &&
               Object.entries(socials)
@@ -74,13 +85,12 @@ export function Footer({ settings }: { settings: SiteSettings }) {
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 px-4 py-6 text-xs text-charcoal/70 sm:flex-row sm:px-6 lg:px-8">
           <p>© {new Date().getFullYear()} {settings.siteName}. All rights reserved.</p>
           <div className="flex flex-wrap items-center gap-4">
-            <Link href="/privacy" className="hover:text-brand-primary">
-              Privacy
-            </Link>
-            <Link href="/terms" className="hover:text-brand-primary">
-              Terms
-            </Link>
-            <span>Built with care for the Cranbourne community.</span>
+            {footerLinks.map((link) => (
+              <Link key={link.href} href={link.href} className="hover:text-brand-primary">
+                {link.label}
+              </Link>
+            ))}
+            {bottomNote && <span>{bottomNote}</span>}
           </div>
         </div>
       </div>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,43 +1,101 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Menu, X } from "lucide-react";
 
+import type { NavigationItem, SiteSettings } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-const NAV_ITEMS = [
+const DEFAULT_NAV_ITEMS: NavigationItem[] = [
   { label: "Home", href: "/" },
   { label: "Stats", href: "/stats" },
-  { label: "Donate", href: "/donate" },
+  { label: "Donate", href: "/donate", variant: "button" },
   { label: "Volunteer", href: "/volunteer" },
-  { label: "About Us", href: "/about" },
-  { label: "Sponsors & Partners", href: "/sponsors" },
+  { label: "About", href: "/about" },
+  { label: "Sponsors", href: "/sponsors" },
 ];
 
-export function Header({ siteName }: { siteName: string }) {
+function getInitials(name: string) {
+  const words = name
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter(Boolean);
+  if (words.length === 0) return "";
+  const initials = words.slice(0, 2).map((word) => word[0]?.toUpperCase() ?? "");
+  return initials.join("");
+}
+
+function getNavItems(settings: SiteSettings) {
+  if (settings.navigation && settings.navigation.length > 0) {
+    return settings.navigation;
+  }
+  return DEFAULT_NAV_ITEMS;
+}
+
+function linkClasses(variant: NavigationItem["variant"], isDesktop: boolean) {
+  if (variant === "button") {
+    const base =
+      "items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2";
+    if (isDesktop) {
+      return cn(
+        "inline-flex",
+        base,
+        "bg-brand-primary text-white shadow-soft hover:bg-brand-primary/90 focus-visible:outline-brand-primary"
+      );
+    }
+    return cn(
+      "flex w-full text-base",
+      base,
+      "bg-brand-primary text-white shadow-soft hover:bg-brand-primary/90 focus-visible:outline-brand-primary"
+    );
+  }
+
+  const base =
+    "rounded-full px-3 py-2 text-sm font-medium text-charcoal transition hover:bg-brand-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary";
+  if (isDesktop) {
+    return base;
+  }
+  return cn(base, "block w-full text-base");
+}
+
+export function Header({ settings }: { settings: SiteSettings }) {
   const [isOpen, setIsOpen] = useState(false);
 
   const toggle = () => setIsOpen((prev) => !prev);
   const close = () => setIsOpen(false);
 
+  const navItems = useMemo(() => getNavItems(settings), [settings]);
+  const initials = useMemo(() => getInitials(settings.siteName), [settings.siteName]);
+
   return (
     <header className="sticky top-0 z-50 border-b border-white/40 bg-white/85 backdrop-blur">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-3" onClick={close}>
-          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-primary/15 font-semibold text-brand-primary">
-            CF
-          </span>
-          <span className="text-lg font-semibold text-charcoal sm:text-xl">{siteName}</span>
+          {settings.logo ? (
+            <span className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-white">
+              <Image
+                src={settings.logo}
+                alt={`${settings.siteName} logo`}
+                fill
+                className="object-contain"
+                sizes="48px"
+              />
+            </span>
+          ) : (
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-primary/15 font-semibold text-brand-primary">
+              {initials || settings.siteName[0] || ""}
+            </span>
+          )}
+          <span className="text-lg font-semibold text-charcoal sm:text-xl">{settings.siteName}</span>
         </Link>
         <nav className="hidden items-center gap-8 text-sm font-medium md:flex">
-          {NAV_ITEMS.map((item) => (
+          {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className={cn(
-                "rounded-full px-3 py-2 transition hover:bg-brand-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
-              )}
+              className={linkClasses(item.variant, true)}
             >
               {item.label}
             </Link>
@@ -62,11 +120,11 @@ export function Header({ siteName }: { siteName: string }) {
         )}
       >
         <div className="space-y-2 border-t border-white/60 bg-white px-4 py-4 shadow-lg">
-          {NAV_ITEMS.map((item) => (
+          {navItems.map((item) => (
             <Link
               key={item.href}
               href={item.href}
-              className="block rounded-xl px-4 py-3 text-base font-medium text-charcoal transition hover:bg-brand-primary/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+              className={linkClasses(item.variant, false)}
               onClick={close}
             >
               {item.label}

--- a/components/stats/kpi-bar.tsx
+++ b/components/stats/kpi-bar.tsx
@@ -6,40 +6,47 @@ import { formatFullDate } from "@/lib/utils";
 
 import { KPICounter } from "@/components/shared/kpi-counter";
 
-export function KPIBar({ fallbackTotals, fallbackLatestService }: { fallbackTotals: StatsSettings["fallbackTotals"]; fallbackLatestService: StatsSettings["fallbackLatestService"]; }) {
+export function KPIBar({ stats }: { stats: StatsSettings }) {
+  const { fallbackTotals, fallbackLatestService, latestSection, totalsSection } = stats;
   const { data, error } = useStats();
 
   const totals = data?.totals ?? fallbackTotals;
   const latest = data?.latestService ?? fallbackLatestService;
+  const latestLabels = latestSection?.metrics ?? {};
+  const totalsLabels = totalsSection?.metrics ?? {};
+  const latestEyebrow = latestSection?.eyebrow ?? "Latest service";
+  const latestSrLabel = latestSection?.srLabel ?? "Most recent service";
+  const streamingMessage = latestSection?.streamingMessage ?? "Streaming directly from our Google Sheet";
+  const fallbackMessage = latestSection?.fallbackMessage ?? "Showing fallback numbers from CMS";
 
   return (
     <section className="mx-auto mt-10 max-w-6xl space-y-6 px-4 sm:px-6 lg:px-8">
       <div className="rounded-3xl bg-white p-6 shadow-soft">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-primary/70">Latest service</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-primary/70">{latestEyebrow}</p>
             <h2 className="mt-2 text-2xl font-semibold text-charcoal">
-              {formatFullDate(latest.date, "Most recent service")}
+              {formatFullDate(latest.date, latestSrLabel)}
             </h2>
             <p className="text-sm text-charcoal/70">
-              {error ? "Showing fallback numbers from CMS" : "Streaming directly from our Google Sheet"}
+              {error ? fallbackMessage : streamingMessage}
             </p>
           </div>
           <div className="grid flex-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <div className="rounded-2xl bg-sand/70 p-4 text-sm">
-              <p className="font-semibold text-charcoal/90">Meals served</p>
+              <p className="font-semibold text-charcoal/90">{latestLabels.meals ?? "Meals served"}</p>
               <p className="mt-1 text-2xl font-semibold text-brand-primary">{latest.meals}</p>
             </div>
             <div className="rounded-2xl bg-sand/70 p-4 text-sm">
-              <p className="font-semibold text-charcoal/90">Guests welcomed</p>
+              <p className="font-semibold text-charcoal/90">{latestLabels.guests ?? "Guests welcomed"}</p>
               <p className="mt-1 text-2xl font-semibold text-brand-primary">{latest.guests}</p>
             </div>
             <div className="rounded-2xl bg-sand/70 p-4 text-sm">
-              <p className="font-semibold text-charcoal/90">Volunteers rostered</p>
+              <p className="font-semibold text-charcoal/90">{latestLabels.volunteers ?? "Volunteers rostered"}</p>
               <p className="mt-1 text-2xl font-semibold text-brand-primary">{latest.volunteers}</p>
             </div>
             <div className="rounded-2xl bg-sand/70 p-4 text-sm">
-              <p className="font-semibold text-charcoal/90">Grocery packs</p>
+              <p className="font-semibold text-charcoal/90">{latestLabels.groceries ?? "Grocery packs"}</p>
               <p className="mt-1 text-2xl font-semibold text-brand-primary">{latest.groceries}</p>
             </div>
           </div>
@@ -47,16 +54,16 @@ export function KPIBar({ fallbackTotals, fallbackLatestService }: { fallbackTota
       </div>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <div className="rounded-3xl bg-white p-6 shadow-soft">
-          <KPICounter label="Total meals" value={totals.meals} />
+          <KPICounter label={totalsLabels.meals ?? "Total meals"} value={totals.meals} />
         </div>
         <div className="rounded-3xl bg-white p-6 shadow-soft">
-          <KPICounter label="Guests welcomed" value={totals.guests} />
+          <KPICounter label={totalsLabels.guests ?? "Guests welcomed"} value={totals.guests} />
         </div>
         <div className="rounded-3xl bg-white p-6 shadow-soft">
-          <KPICounter label="Volunteers" value={totals.volunteers} />
+          <KPICounter label={totalsLabels.volunteers ?? "Volunteers"} value={totals.volunteers} />
         </div>
         <div className="rounded-3xl bg-white p-6 shadow-soft">
-          <KPICounter label="Services" value={totals.services} />
+          <KPICounter label={totalsLabels.services ?? "Services"} value={totals.services} />
         </div>
       </div>
     </section>

--- a/components/stats/looker-embed.tsx
+++ b/components/stats/looker-embed.tsx
@@ -1,18 +1,28 @@
-import type { LookerSettings } from "@/lib/types";
+import type { LookerSettings, StatsSettings } from "@/lib/types";
 
-export function LookerEmbed({ looker }: { looker?: LookerSettings }) {
+export function LookerEmbed({
+  looker,
+  dashboard,
+}: {
+  looker?: LookerSettings;
+  dashboard?: StatsSettings["dashboardSection"];
+}) {
   if (!looker?.statsUrl) return null;
+
+  const heading = dashboard?.title ?? "Interactive dashboard";
+  const description = dashboard?.description ?? looker.embedTitle;
+  const iframeTitle = looker.embedTitle ?? heading;
 
   return (
     <section className="mx-auto mt-16 max-w-6xl px-4 sm:px-6 lg:px-8">
       <div className="rounded-3xl bg-white p-6 shadow-soft">
         <div className="mb-6">
-          <h2 className="text-2xl font-semibold text-charcoal">Interactive dashboard</h2>
-          {looker.embedTitle && <p className="text-sm text-charcoal/70">{looker.embedTitle}</p>}
+          <h2 className="text-2xl font-semibold text-charcoal">{heading}</h2>
+          {description && <p className="text-sm text-charcoal/70">{description}</p>}
         </div>
         <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl">
           <iframe
-            title={looker.embedTitle ?? "Looker Studio dashboard"}
+            title={iframeTitle}
             src={looker.statsUrl}
             className="h-full w-full border-0"
             allowFullScreen

--- a/components/volunteer/tally-embed.tsx
+++ b/components/volunteer/tally-embed.tsx
@@ -1,18 +1,29 @@
 import type { SiteSettings } from "@/lib/types";
 
-export function TallyEmbed({ tallyUrl }: { tallyUrl?: SiteSettings["tallyFormUrl"] }) {
+export function TallyEmbed({
+  tallyUrl,
+  form,
+}: {
+  tallyUrl?: SiteSettings["tallyFormUrl"];
+  form?: SiteSettings["volunteerForm"];
+}) {
+  const placeholderTitle = form?.placeholderTitle ?? "Volunteer form coming soon";
+  const placeholderBody =
+    form?.placeholderBody ?? "Add your Tally.so form URL in the CMS to display it here.";
+  const iframeTitle = form?.iframeTitle ?? "Volunteer expression of interest form";
+
   return (
     <>
       {!tallyUrl ? (
         <div className="mx-auto mt-12 max-w-4xl rounded-3xl border border-dashed border-brand-primary/40 bg-white/60 p-10 text-center text-sm text-charcoal/70">
-          <p className="font-semibold text-charcoal">Volunteer form coming soon</p>
-          <p className="mt-2">Add your Tally.so form URL in the CMS to display it here.</p>
+          <p className="font-semibold text-charcoal">{placeholderTitle}</p>
+          <p className="mt-2">{placeholderBody}</p>
         </div>
       ) : (
         <div className="mx-auto mt-12 max-w-4xl overflow-hidden rounded-3xl bg-white shadow-soft">
           <iframe
             src={tallyUrl}
-            title="Volunteer expression of interest form"
+            title={iframeTitle}
             className="h-[900px] w-full border-0"
             allow="fullscreen"
           />

--- a/content/home.yaml
+++ b/content/home.yaml
@@ -3,6 +3,7 @@ hero:
   headline: "A welcoming meal for anyone who needs it"
   subheadline: "Our volunteer-powered food truck offers hot dinners, pantry staples and friendly faces every Tuesday and Thursday night."
   image: "/images/hero-gathering.svg"
+  imageAlt: "Community members gathered at the Cranbourne Food Truck"
   ctas:
     primary:
       label: "Need a meal? Find us"

--- a/content/legal/privacy.md
+++ b/content/legal/privacy.md
@@ -1,0 +1,10 @@
+---
+title: "Privacy"
+description: "Privacy statement for Cranbourne Food Truck guests, supporters and volunteers."
+---
+
+## Privacy statement
+
+This is a placeholder privacy statement. Update this page through the CMS with your organisation’s privacy policy, including how you collect, use and store personal information.
+
+For questions please email [hello@cranbournefoodtruck.com](mailto:hello@cranbournefoodtruck.com).

--- a/content/legal/terms.md
+++ b/content/legal/terms.md
@@ -1,0 +1,10 @@
+---
+title: "Terms"
+description: "Terms of use for Cranbourne Food Truck services and website."
+---
+
+## Terms of use
+
+This is a placeholder terms of use page. Provide your service terms through the CMS, including participation expectations, disclaimers and any limitations of liability.
+
+Contact us at [hello@cranbournefoodtruck.com](mailto:hello@cranbournefoodtruck.com) with any questions.

--- a/content/site-settings.yaml
+++ b/content/site-settings.yaml
@@ -2,6 +2,20 @@ siteName: Cranbourne Food Truck
 siteTagline: Nourishing community with dignity and care.
 logo: ""
 primaryColor: "#C3423F"
+navigation:
+  - label: "Home"
+    href: "/"
+  - label: "Stats"
+    href: "/stats"
+  - label: "Donate"
+    href: "/donate"
+    variant: "button"
+  - label: "Volunteer"
+    href: "/volunteer"
+  - label: "About Us"
+    href: "/about"
+  - label: "Sponsors & Partners"
+    href: "/sponsors"
 contact:
   email: "hello@cranbournefoodtruck.com"
   phone: "(03) 9000 0000"
@@ -23,6 +37,20 @@ donate:
   paypal: "https://www.paypal.com/donate"
   stripe: "https://buy.stripe.com/test_1234567890"
   note: "Donations of $2 or more are tax deductible. Receipts issued within 5 business days."
+donationCopy:
+  bankSection:
+    eyebrow: "Direct deposit"
+    title: "Bank transfer details"
+    fieldLabels:
+      accountName: "Account name"
+      bsb: "BSB"
+      accountNumber: "Account number"
+      reference: "Reference"
+  onlineSection:
+    eyebrow: "Give online"
+    title: "Secure donate links"
+    paypalLabel: "Donate via PayPal"
+    stripeLabel: "Donate via Stripe"
 map:
   embedUrl: "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3151.8354345098575!2d144.9556513153166!3d-37.817327979751795!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zMzfCsDQ5JzAyLjQiUyAxNDTCsDU3JzI2LjAiRQ!5e0!3m2!1sen!2sau!4v1613960648896!5m2!1sen!2sau"
   directionsUrl: "https://maps.google.com/?q=Cranbourne+Community+Hub"
@@ -39,10 +67,31 @@ service:
     - "Family friendly space with play corner."
     - "Bring your own containers if you can."
   ctaLabel: "View directions"
+  labels:
+    heroEyebrow: "This week’s service"
+    sectionEyebrow: "Service details"
+    notesTitle: "What to expect"
+    callCta: "Call us"
+    emailCta: "Email the team"
+    mapTitle: "Service location map"
 lookers:
   statsUrl: "https://lookerstudio.google.com/reporting/placeholder"
   embedTitle: "Cranbourne Food Truck Service Trends"
 tallyFormUrl: "https://tally.so/r/placeholder"
+volunteerForm:
+  placeholderTitle: "Volunteer form coming soon"
+  placeholderBody: "Add your Tally.so form URL in the CMS to display it here."
+  iframeTitle: "Volunteer expression of interest form"
+footer:
+  contactHeading: "Stay connected"
+  contactBody: "We’re here to serve our Cranbourne neighbours with warmth and dignity."
+  socialHeading: "Follow our journey"
+  bottomNote: "Built with care for the Cranbourne community."
+  links:
+    - label: "Privacy"
+      href: "/privacy"
+    - label: "Terms"
+      href: "/terms"
 analytics:
   gaMeasurementId: ""
 seo:

--- a/content/stats-settings.yaml
+++ b/content/stats-settings.yaml
@@ -21,6 +21,28 @@ fallbackLatestService:
   volunteers: 28
   groceries: 95
   notes: "Pop-up haircuts and health clinic onsite."
+page:
+  heading: "Service stats"
+  intro: "Live counts of meals, guests and volunteers powered by our Google Sheet. Explore deeper trends via the interactive dashboard below."
+latestSection:
+  eyebrow: "Latest service"
+  srLabel: "Most recent service"
+  streamingMessage: "Streaming directly from our Google Sheet"
+  fallbackMessage: "Showing fallback numbers from CMS"
+  metrics:
+    meals: "Meals served"
+    guests: "Guests welcomed"
+    volunteers: "Volunteers rostered"
+    groceries: "Grocery packs"
+totalsSection:
+  metrics:
+    meals: "Total meals"
+    guests: "Guests welcomed"
+    volunteers: "Volunteers"
+    services: "Services"
+dashboardSection:
+  title: "Interactive dashboard"
+  description: "Explore the full service trends dashboard below."
 lookers:
   statsUrl: "https://lookerstudio.google.com/reporting/placeholder"
   embedTitle: "Service trends dashboard"

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -8,6 +8,7 @@ import type {
   AboutContent,
   DonateContent,
   HomeContent,
+  LegalPageContent,
   Partner,
   SiteSettings,
   SponsorsContent,
@@ -32,6 +33,12 @@ const readYamlFile = cache(async <T>(fileName: string): Promise<T> => {
   const filePath = path.join(CONTENT_DIR, fileName);
   const file = await readFileSafe(filePath);
   return YAML.parse(file) as T;
+});
+
+const readMarkdownFile = cache(async (fileName: string) => {
+  const filePath = path.join(CONTENT_DIR, fileName);
+  const file = await readFileSafe(filePath);
+  return matter(file);
 });
 
 async function readMarkdownCollection<T extends { slug: string }>(
@@ -147,4 +154,15 @@ export const getPartners = cache(async (): Promise<Partner[]> => {
   });
 
   return partners.sort((a, b) => (a.order ?? 99) - (b.order ?? 99));
+});
+
+export const getLegalPage = cache(async (slug: "privacy" | "terms"): Promise<LegalPageContent> => {
+  const { data, content } = await readMarkdownFile(path.join("legal", `${slug}.md`));
+  const record = data as Record<string, unknown>;
+
+  return {
+    title: typeof record.title === "string" ? record.title : slug,
+    description: typeof record.description === "string" ? record.description : undefined,
+    body: content.trim(),
+  } satisfies LegalPageContent;
 });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,9 +28,37 @@ export type DonateLinks = {
   note?: string;
 };
 
+export type DonationCopy = {
+  bankSection?: {
+    eyebrow?: string;
+    title?: string;
+    fieldLabels?: {
+      accountName?: string;
+      bsb?: string;
+      accountNumber?: string;
+      reference?: string;
+    };
+  };
+  onlineSection?: {
+    eyebrow?: string;
+    title?: string;
+    paypalLabel?: string;
+    stripeLabel?: string;
+  };
+};
+
 export type MapSettings = {
   embedUrl?: string;
   directionsUrl?: string;
+};
+
+export type ServiceLabels = {
+  heroEyebrow?: string;
+  sectionEyebrow?: string;
+  notesTitle?: string;
+  callCta?: string;
+  emailCta?: string;
+  mapTitle?: string;
 };
 
 export type ServiceDetails = {
@@ -43,6 +71,7 @@ export type ServiceDetails = {
   email?: string;
   notes?: string[];
   ctaLabel?: string;
+  labels?: ServiceLabels;
 };
 
 export type LookerSettings = {
@@ -52,6 +81,31 @@ export type LookerSettings = {
 
 export type AnalyticsSettings = {
   gaMeasurementId?: string;
+};
+
+export type NavigationItem = {
+  label: string;
+  href: string;
+  variant?: "link" | "button";
+};
+
+export type FooterLink = {
+  label: string;
+  href: string;
+};
+
+export type FooterSettings = {
+  contactHeading?: string;
+  contactBody?: string;
+  socialHeading?: string;
+  bottomNote?: string;
+  links?: FooterLink[];
+};
+
+export type VolunteerFormSettings = {
+  placeholderTitle?: string;
+  placeholderBody?: string;
+  iframeTitle?: string;
 };
 
 export type SeoSettings = {
@@ -66,12 +120,16 @@ export type SiteSettings = {
   primaryColor?: string;
   contact: ContactDetails;
   socials?: SocialLinks;
+  navigation?: NavigationItem[];
   bank?: BankDetails;
   donate?: DonateLinks;
+  donationCopy?: DonationCopy;
   map?: MapSettings;
   service?: ServiceDetails;
   lookers?: LookerSettings;
   tallyFormUrl?: string;
+  volunteerForm?: VolunteerFormSettings;
+  footer?: FooterSettings;
   analytics?: AnalyticsSettings;
   seo?: SeoSettings;
 };
@@ -86,6 +144,7 @@ export type HomeHero = {
   headline: string;
   subheadline?: string;
   image?: string;
+  imageAlt?: string;
   ctas: {
     primary: HomeHeroCta;
     secondary?: HomeHeroCta;
@@ -163,6 +222,34 @@ export type StatsSettings = {
     notes?: string;
   };
   lookers?: LookerSettings;
+  page?: {
+    heading?: string;
+    intro?: string;
+  };
+  latestSection?: {
+    eyebrow?: string;
+    srLabel?: string;
+    streamingMessage?: string;
+    fallbackMessage?: string;
+    metrics?: {
+      meals?: string;
+      guests?: string;
+      volunteers?: string;
+      groceries?: string;
+    };
+  };
+  totalsSection?: {
+    metrics?: {
+      meals?: string;
+      guests?: string;
+      volunteers?: string;
+      services?: string;
+    };
+  };
+  dashboardSection?: {
+    title?: string;
+    description?: string;
+  };
   seo?: {
     title?: string;
     description?: string;
@@ -253,6 +340,12 @@ export type SponsorsContent = {
     title?: string;
     description?: string;
   };
+};
+
+export type LegalPageContent = {
+  title: string;
+  description?: string;
+  body: string;
 };
 
 export type StatsApiLatestService = {


### PR DESCRIPTION
## Summary
- add Netlify CMS fields for navigation, footer, donation copy, volunteer form, stats text, and legal pages
- wire frontend components to consume the new CMS-managed content and fall back gracefully when optional copy is missing
- load privacy and terms content from markdown files managed in the CMS

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d131fbec8c8331a21bb179fc438c68