### PR TITLE
Fix legal collection config entry

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -519,4 +519,3 @@ collections:
           - { label: "Title", name: "title", widget: "string" }
           - { label: "Description", name: "description", widget: "string", required: false }
           - { label: "Body", name: "body", widget: "markdown" }
-      - { label: "Display Order", name: "order", widget: "number", required: false }


### PR DESCRIPTION
## Summary
- remove the stray display order field entry from the legal collection in the CMS config so it validates correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d13dfa98a8833191a7c669037fcb69