### PR TITLE
Fix CMS config API for edge runtime

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+declare module "*.yml" {
+  const content: string;
+  export default content;
+}
+
+declare module "*.yaml" {
+  const content: string;
+  export default content;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,14 @@ const nextConfig = {
       },
     ];
   },
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.ya?ml$/i,
+      type: "asset/source",
+    });
+
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- update the CMS configuration API to run on the Edge runtime by loading the YAML template at build time
- configure Next.js to import YAML files as raw strings and add TypeScript declarations for YAML modules

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1444ab138833186a95f6982ed6528