### PR TITLE
Make OAuth callback URI configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ The app will be available at [http://localhost:3000](http://localhost:3000).
    - `DECAP_GITHUB_CLIENT_ID` / `DECAP_GITHUB_CLIENT_SECRET` – credentials for the built-in GitHub OAuth flow (alternatively, set `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`).
    - `DECAP_OAUTH_BASE_URL` – origin for your OAuth provider (for example `https://cms-auth.example.com`).
    - `DECAP_OAUTH_ENDPOINT` – endpoint path served by the provider (for example `/api/auth`).
+   - `DECAP_OAUTH_CALLBACK_PATH` – optional override for the callback path appended to the base URL (defaults to `callback`).
+   - `DECAP_OAUTH_CALLBACK_URL` – optional full callback URL override when you need an exact redirect URI for your OAuth app.
    - `DECAP_SITE_URL` / `DECAP_DISPLAY_URL` – optional values to control site and preview URLs displayed inside the CMS UI.
 4. Visit `/admin` on the deployed site to access the CMS once authentication is configured.
 5. Collections available:

--- a/app/api/oauth/auth/route.ts
+++ b/app/api/oauth/auth/route.ts
@@ -2,9 +2,73 @@ import { NextResponse } from "next/server";
 
 import { getGitHubClientId } from "../env";
 
+function toTrimmedOrUndefined(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function ensureTrailingSlash(url: URL) {
+  if (!url.pathname.endsWith("/")) {
+    url.pathname = `${url.pathname}/`;
+  }
+}
+
+function resolveRedirectUri(requestUrl: URL) {
+  const fallback = new URL("/api/oauth/callback", requestUrl.origin);
+
+  const callbackUrlOverride = toTrimmedOrUndefined(
+    process.env.DECAP_OAUTH_CALLBACK_URL
+  );
+
+  if (callbackUrlOverride) {
+    try {
+      return new URL(callbackUrlOverride, requestUrl.origin).toString();
+    } catch (error) {
+      console.warn(
+        "Invalid DECAP_OAUTH_CALLBACK_URL provided, falling back to default callback URI.",
+        error
+      );
+    }
+  }
+
+  const baseUrlOverride = toTrimmedOrUndefined(
+    process.env.DECAP_OAUTH_BASE_URL
+  );
+  const callbackPathOverride = toTrimmedOrUndefined(
+    process.env.DECAP_OAUTH_CALLBACK_PATH
+  );
+
+  if (baseUrlOverride || callbackPathOverride) {
+    try {
+      const baseUrl = new URL(
+        baseUrlOverride ?? "/api/oauth",
+        requestUrl.origin
+      );
+      ensureTrailingSlash(baseUrl);
+
+      if (callbackPathOverride) {
+        return new URL(callbackPathOverride, baseUrl).toString();
+      }
+
+      return new URL("callback", baseUrl).toString();
+    } catch (error) {
+      console.warn(
+        "Unable to resolve OAuth callback URL from overrides, falling back to default callback URI.",
+        error
+      );
+    }
+  }
+
+  return fallback.toString();
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const redirectUri = `${url.origin}/api/oauth/callback`;
+  const redirectUri = resolveRedirectUri(url);
   const clientId = getGitHubClientId();
 
   if (!clientId) {


### PR DESCRIPTION
## Summary
- allow overriding the Decap OAuth callback URL via environment variables so the redirect can match the GitHub OAuth app configuration
- document the new callback override options alongside the other CMS environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ca42e13483318e742a2d15d98a09