### PR TITLE
Allow overriding Decap OAuth callback domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The app will be available at [http://localhost:3000](http://localhost:3000).
    - `DECAP_GITHUB_CLIENT_ID` / `DECAP_GITHUB_CLIENT_SECRET` – credentials for the built-in GitHub OAuth flow (alternatively, set `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`).
    - `DECAP_OAUTH_BASE_URL` – origin for your OAuth provider (for example `https://cms-auth.example.com`).
    - `DECAP_OAUTH_ENDPOINT` – endpoint path served by the provider (for example `/api/auth`).
+   - `DECAP_OAUTH_CALLBACK_URL` – optional override for the redirect URI sent to GitHub (useful when your OAuth app only accepts a specific domain). Alternatively set `DECAP_OAUTH_CALLBACK_PATH` to customise just the path while keeping the host from `DECAP_SITE_URL`.
    - `DECAP_SITE_URL` / `DECAP_DISPLAY_URL` – optional values to control site and preview URLs displayed inside the CMS UI.
 4. Visit `/admin` on the deployed site to access the CMS once authentication is configured.
 5. Collections available:

--- a/app/api/oauth/config.ts
+++ b/app/api/oauth/config.ts
@@ -1,0 +1,105 @@
+import {
+  getOAuthCallbackPath,
+  getOAuthCallbackUrl,
+  getSiteUrl,
+} from "./env";
+
+const DEFAULT_CALLBACK_PATH = "/api/oauth/callback";
+
+function normalisePath(path: string) {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function parseUrl(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return new URL(value);
+  } catch (error) {
+    console.warn(
+      "Invalid URL provided for OAuth configuration, ignoring value:",
+      value,
+      error instanceof Error ? error.message : error
+    );
+    return undefined;
+  }
+}
+
+function getSharedDomain(hosts: (string | undefined)[]) {
+  const partsList = hosts
+    .filter((host): host is string => Boolean(host && host.trim().length > 0))
+    .map((host) => host.toLowerCase().split(".").filter(Boolean));
+
+  if (partsList.length === 0) {
+    return undefined;
+  }
+
+  let candidate = partsList[0];
+
+  for (const parts of partsList.slice(1)) {
+    const shared: string[] = [];
+    const maxLength = Math.min(candidate.length, parts.length);
+
+    for (let i = 1; i <= maxLength; i += 1) {
+      const candidatePart = candidate[candidate.length - i];
+      const part = parts[parts.length - i];
+
+      if (!candidatePart || candidatePart !== part) {
+        break;
+      }
+
+      shared.unshift(candidatePart);
+    }
+
+    candidate = shared;
+
+    if (candidate.length === 0) {
+      break;
+    }
+  }
+
+  if (candidate.length < 2) {
+    return undefined;
+  }
+
+  return candidate.join(".");
+}
+
+export function resolveCallbackUrl(requestUrl: URL) {
+  const explicitCallback = parseUrl(getOAuthCallbackUrl());
+
+  if (explicitCallback) {
+    return explicitCallback;
+  }
+
+  const siteUrl = parseUrl(getSiteUrl());
+  const baseOrigin = siteUrl?.origin ?? requestUrl.origin;
+
+  const callbackPath = getOAuthCallbackPath();
+
+  if (callbackPath) {
+    try {
+      return new URL(normalisePath(callbackPath), baseOrigin);
+    } catch (error) {
+      console.warn(
+        "Failed to resolve OAuth callback path, falling back to default path:",
+        callbackPath,
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+
+  return new URL(DEFAULT_CALLBACK_PATH, baseOrigin);
+}
+
+export function getOAuthCookieDomain(requestUrl: URL, callbackUrl: URL) {
+  const siteUrl = parseUrl(getSiteUrl());
+
+  return getSharedDomain([
+    requestUrl.hostname,
+    callbackUrl.hostname,
+    siteUrl?.hostname,
+  ]);
+}

--- a/app/api/oauth/env.ts
+++ b/app/api/oauth/env.ts
@@ -17,3 +17,16 @@ export const getGitHubClientId = () =>
 
 export const getGitHubClientSecret = () =>
   pickEnv("GITHUB_CLIENT_SECRET", "DECAP_GITHUB_CLIENT_SECRET");
+
+export const getOAuthCallbackUrl = () =>
+  pickEnv(
+    "DECAP_OAUTH_CALLBACK_URL",
+    "DECAP_OAUTH_REDIRECT_URL",
+    "DECAP_OAUTH_REDIRECT_URI"
+  );
+
+export const getOAuthCallbackPath = () =>
+  pickEnv("DECAP_OAUTH_CALLBACK_PATH", "DECAP_OAUTH_REDIRECT_PATH");
+
+export const getSiteUrl = () =>
+  pickEnv("DECAP_SITE_URL", "SITE_URL", "NEXT_PUBLIC_SITE_URL");


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the GitHub OAuth callback URL and compute a shared cookie domain
- update the OAuth auth and callback routes to honour the resolved URL and keep cookies valid across matching hosts
- document the optional `DECAP_OAUTH_CALLBACK_URL` / `DECAP_OAUTH_CALLBACK_PATH` overrides for Cloudflare deployments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ca42e13483318e742a2d15d98a09