### PR TITLE
Fix OAuth popup token handling

### DIFF
--- a/app/api/oauth/auth/route.ts
+++ b/app/api/oauth/auth/route.ts
@@ -1,44 +1,23 @@
 import { NextResponse } from "next/server";
 
-import { getGitHubClientId, getOAuthBaseUrl } from "../env";
+export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const url = new URL(req.url);
-  const baseOverride = getOAuthBaseUrl();
-  const redirectUri = (() => {
-    try {
-      const base = baseOverride ?? url.origin;
-      return new URL("/api/oauth/callback", base).toString().replace(/\/$/, "");
-    } catch {
-      return `${url.origin}/api/oauth/callback`;
-    }
-  })();
-  const clientId = getGitHubClientId();
-
-  if (!clientId) {
-    return new NextResponse(
-      "GitHub OAuth client ID is not configured. Set GITHUB_CLIENT_ID or DECAP_GITHUB_CLIENT_ID.",
-      {
-        status: 500,
-      }
-    );
-  }
-
+  const base = process.env.OAUTH_BASE_URL ?? new URL(req.url).origin;
+  const redirectUri = `${base}/api/oauth/callback`;
+  const clientId = process.env.GITHUB_CLIENT_ID!;
   const state = crypto.randomUUID();
-  const authorizeUrl = new URL("https://github.com/login/oauth/authorize");
-  authorizeUrl.searchParams.set("client_id", clientId);
-  authorizeUrl.searchParams.set("redirect_uri", redirectUri);
-  authorizeUrl.searchParams.set("scope", "repo user:email");
-  authorizeUrl.searchParams.set("state", state);
 
-  const response = NextResponse.redirect(authorizeUrl.toString());
-  response.cookies.set("decap_oauth_state", state, {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 600,
-    path: "/",
+  const url = new URL("https://github.com/login/oauth/authorize");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("scope", "repo user:email");
+  url.searchParams.set("state", state);
+
+  const res = NextResponse.redirect(url.toString());
+  // set cookie on the RESPONSE, not via next/headers
+  res.cookies.set("decap_oauth_state", state, {
+    httpOnly: true, secure: true, sameSite: "lax", path: "/", maxAge: 600
   });
-
-  return response;
+  return res;
 }

--- a/app/api/oauth/callback/route.ts
+++ b/app/api/oauth/callback/route.ts
@@ -1,78 +1,50 @@
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
 
-import { getGitHubClientId, getGitHubClientSecret } from "../env";
-
-type AccessTokenResponse = {
-  access_token?: string;
-  error?: string;
-  error_description?: string;
-};
+export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
-  const { cookies } = await import("next/headers");
   const cookieState = cookies().get("decap_oauth_state")?.value;
 
-  if (!code || !state || !cookieState || state !== cookieState) {
+  if (!code || !state || state !== cookieState) {
     return new NextResponse("Invalid OAuth state", { status: 400 });
   }
 
-  const clientId = getGitHubClientId();
-  const clientSecret = getGitHubClientSecret();
-
-  if (!clientId || !clientSecret) {
-    return new NextResponse(
-      "GitHub OAuth credentials are not configured. Set GITHUB_CLIENT_ID/GITHUB_CLIENT_SECRET or their DECAP_ equivalents.",
-      {
-        status: 500,
-      }
-    );
-  }
-
   const body = new URLSearchParams({
-    client_id: clientId,
-    client_secret: clientSecret,
-    code,
+    client_id: process.env.GITHUB_CLIENT_ID!,
+    client_secret: process.env.GITHUB_CLIENT_SECRET!,
+    code
   });
 
-  const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
+  const r = await fetch("https://github.com/login/oauth/access_token", {
     method: "POST",
     headers: { Accept: "application/json" },
-    body,
+    body
   });
+  const data = (await r.json()) as { access_token?: string; error?: string };
 
-  if (!tokenResponse.ok) {
+  if (!data.access_token) {
     return new NextResponse("Auth failed", { status: 400 });
   }
 
-  const json = (await tokenResponse.json()) as AccessTokenResponse;
+  // Send token back to Decap and close popup
+  const html = `<!doctype html><meta charset="utf-8">
+<script>
+  (function(){
+    var payload = JSON.stringify({ token: ${JSON.stringify(data.access_token)} });
+    // Decap listens for this exact message format
+    window.opener && window.opener.postMessage('authorization:github:success:' + payload, '*');
+    window.close();
+  })();
+</script>OK`;
 
-  if (!json.access_token) {
-    return new NextResponse("Auth failed", { status: 400 });
-  }
-
-  const response = new NextResponse(
-    "<html><body><script>window.close()</script>OK</body></html>",
-    { headers: { "Content-Type": "text/html" } }
-  );
-
-  response.cookies.set("decap_token", json.access_token, {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 3600,
-    path: "/",
+  const res = new NextResponse(html, { headers: { "Content-Type": "text/html" } });
+  res.cookies.set("decap_token", data.access_token, {
+    httpOnly: true, secure: true, sameSite: "lax", path: "/", maxAge: 3600
   });
-
-  response.cookies.set("decap_oauth_state", "", {
-    httpOnly: true,
-    secure: true,
-    sameSite: "lax",
-    maxAge: 0,
-    path: "/",
-  });
-
-  return response;
+  res.cookies.delete("decap_oauth_state");
+  return res;
 }


### PR DESCRIPTION
## Summary
- redirect GitHub auth with state cookie written directly on the NextResponse
- validate the OAuth callback, return the access token via postMessage, and store the session cookie

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36bba84ac8331a95360b6f3e5cd7f