### PR TITLE
Fix /admin to render Next.js Decap route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,15 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
-  async redirects() {
-    return [
-      {
-        source: "/admin",
-        destination: "/admin/index.html",
-        permanent: false,
-      },
-    ];
-  },
   webpack(config) {
     config.module.rules.push({
       test: /\.ya?ml$/i,
@@ -20,4 +11,4 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove the Next.js redirect that sent `/admin` to the static HTML file
- convert the Next.js config to CommonJS while keeping the standalone output and YAML loader

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d37513c37883319907274225ed3973