### PR TITLE
Fix Decap CMS init error on admin page

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,93 @@
-// app/admin/page.tsx
-import Script from "next/script";
+"use client";
+
+import { useEffect } from "react";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default function Admin() {
-  return (
-    <>
-      <Script src="https://unpkg.com/decap-cms@^3/dist/decap-cms.js" strategy="afterInteractive" />
-      <Script id="init-decap" strategy="afterInteractive">{`
-        fetch('/api/cms-config', { cache: 'no-store' })
-          .then(r => r.json())
-          .then(cfg => window.CMS && window.CMS.init({ config: cfg }))
-          .catch(() => alert('CMS config failed to load'));
-      `}</Script>
-      <div id="cms-root" />
-    </>
-  );
+  useEffect(() => {
+    window.CMS_MANUAL_INIT = true;
+
+    let isCancelled = false;
+
+    const initializeCms = async () => {
+      if (isCancelled || !window.CMS || window.__decapInitialized) {
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/cms-config", { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const config = await response.json();
+
+        if (!isCancelled) {
+          window.CMS.init({ config });
+          window.__decapInitialized = true;
+        }
+      } catch (error) {
+        window.__decapInitialized = false;
+
+        if (!isCancelled) {
+          console.error("CMS config failed to load", error);
+          alert("CMS config failed to load");
+        }
+      }
+    };
+
+    const handleLoad = () => {
+      void initializeCms();
+    };
+
+    const handleError = () => {
+      if (!isCancelled) {
+        console.error("Failed to load Decap CMS script.");
+        alert("CMS failed to load.");
+      }
+    };
+
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      'script[data-decap-cms="true"]'
+    );
+
+    if (existingScript) {
+      existingScript.addEventListener("load", handleLoad);
+      existingScript.addEventListener("error", handleError);
+
+      if (window.CMS) {
+        void initializeCms();
+      }
+
+      return () => {
+        isCancelled = true;
+        existingScript.removeEventListener("load", handleLoad);
+        existingScript.removeEventListener("error", handleError);
+      };
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://unpkg.com/decap-cms@^3/dist/decap-cms.js";
+    script.async = true;
+    script.dataset.decapCms = "true";
+    script.addEventListener("load", handleLoad);
+    script.addEventListener("error", handleError);
+
+    document.head.appendChild(script);
+
+    return () => {
+      isCancelled = true;
+      script.removeEventListener("load", handleLoad);
+      script.removeEventListener("error", handleError);
+
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, []);
+
+  return <div id="nc-root" />;
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -7,3 +7,15 @@ declare module "*.yaml" {
   const content: string;
   export default content;
 }
+
+declare global {
+  interface Window {
+    CMS?: {
+      init: (options: { config: unknown }) => void;
+    };
+    CMS_MANUAL_INIT?: boolean;
+    __decapInitialized?: boolean;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- load Decap CMS manually in the admin page so the script only initializes once and waits for the config before mounting
- add TypeScript globals for the Decap CMS window fields used by the admin loader

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d37a913df883318ee76bed0cb32953