### PR TITLE
Fix GitHub OAuth flow to use configured credentials

### DIFF
--- a/app/api/oauth/auth/route.ts
+++ b/app/api/oauth/auth/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from "next/server";
 
+import { getGitHubClientId, getOAuthBaseUrl } from "../env";
+
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const base = process.env.OAUTH_BASE_URL ?? new URL(req.url).origin;
+  const base = getOAuthBaseUrl() ?? new URL(req.url).origin;
   const redirectUri = `${base}/api/oauth/callback`;
-  const clientId = process.env.GITHUB_CLIENT_ID!;
+  const clientId = getGitHubClientId();
+  if (!clientId) {
+    return new NextResponse("Missing GitHub OAuth client ID", { status: 500 });
+  }
   const state = crypto.randomUUID();
 
   const url = new URL("https://github.com/login/oauth/authorize");

--- a/app/api/oauth/callback/route.ts
+++ b/app/api/oauth/callback/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 
+import { getGitHubClientId, getGitHubClientSecret } from "../env";
+
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
@@ -13,9 +15,15 @@ export async function GET(req: Request) {
     return new NextResponse("Invalid OAuth state", { status: 400 });
   }
 
+  const clientId = getGitHubClientId();
+  const clientSecret = getGitHubClientSecret();
+  if (!clientId || !clientSecret) {
+    return new NextResponse("Missing GitHub OAuth credentials", { status: 500 });
+  }
+
   const body = new URLSearchParams({
-    client_id: process.env.GITHUB_CLIENT_ID!,
-    client_secret: process.env.GITHUB_CLIENT_SECRET!,
+    client_id: clientId,
+    client_secret: clientSecret,
     code
   });
 


### PR DESCRIPTION
## Summary
- pull GitHub OAuth configuration from the shared environment helpers when starting the auth flow
- add explicit error responses when credentials are missing so we do not generate invalid authorization requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db514d34bc8331869ab08e9e1b8014