### PR TITLE
Add non-technical content editing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The app will be available at [http://localhost:3000](http://localhost:3000).
 
 ## Content editing with Decap CMS
 
+> **Quick reference:** The step-by-step walkthrough that non-technical editors can follow lives at
+> [`/editor-guide`](https://your-domain/editor-guide) on the live site and inside [`docs/editor-guide.md`](docs/editor-guide.md).
+
 1. Deploy the project to Cloudflare Pages. The CMS is pre-configured for the GitHub backend so editors authenticate with their GitHub accounts.
 2. Provision a GitHub OAuth integration (either an OAuth App, GitHub App or the official Decap CMS OAuth provider) and expose it via a Cloudflare Worker or other HTTPS endpoint.
 3. In Cloudflare Pages → **Settings → Environment variables**, add the following values for both Production and Preview environments:
@@ -45,7 +48,8 @@ The app will be available at [http://localhost:3000](http://localhost:3000).
    - **Site Settings** – global contact details, donation links, map embed, service info, social links and analytics.
    - **Home Page**, **Stats Settings**, **About Page**, **Donate Page**, **Volunteer Page**, **Sponsors Page** – single-file collections for main copy and metadata.
    - **Team**, **Stories**, **Partners** – folder collections for repeatable entries with images and optional ordering.
-6. Media uploads are stored in `public/uploads/` and referenced automatically.
+6. Media uploads are stored in `public/uploads/` and referenced automatically. You can upload them straight from the CMS via the
+   **Upload** button next to any image field.
 
 The CMS can also run locally with `npx decap-server` and navigating to `http://localhost:3000/admin`.
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,8 +1,16 @@
 import { AdminApp } from "@/components/admin/AdminApp";
+import { AdminGuide } from "@/components/admin/AdminGuide";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 export default function Admin() {
-  return <AdminApp />;
+  return (
+    <main className="min-h-screen bg-slate-950">
+      <AdminGuide />
+      <div className="min-h-[70vh]">
+        <AdminApp />
+      </div>
+    </main>
+  );
 }

--- a/app/editor-guide/page.tsx
+++ b/app/editor-guide/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Content editor guide",
+  description:
+    "Step-by-step instructions for updating copy, photos and logos in the Cranbourne Food Truck website CMS.",
+};
+
+const sections = [
+  {
+    title: "1. Sign in",
+    body: [
+      "Visit https://<your-domain>/admin.",
+      "Click **Log in with GitHub** and authorise access. Ask the administrator to invite you if you cannot sign in yet.",
+      "The editor runs entirely in your browser – no extra software is required.",
+    ],
+  },
+  {
+    title: "2. Pick something to edit",
+    body: [
+      "Use the left-hand sidebar to select a collection. Single pages such as **Home Page** or **Donate Page** open directly.",
+      "Collections like **Team**, **Stories** or **Partners** show a list of existing entries with a **New** button for adding more.",
+      "Global items (logos, navigation, donation links, contact details) live in **Site Settings**.",
+    ],
+  },
+  {
+    title: "3. Update copy",
+    body: [
+      "Click into any field and type your changes. Nothing goes live until you publish.",
+      "Rich text areas include buttons for headings, bold, lists, links and quotes – no Markdown knowledge needed.",
+      "Undo works with Ctrl/Cmd + Z just like a word processor.",
+    ],
+  },
+  {
+    title: "4. Add photos or logos",
+    body: [
+      "Find an **Image** field and press **Upload**.",
+      "Choose a JPG, PNG or SVG from your computer. The CMS stores it in the site uploads folder automatically.",
+      "Switch to the **Media Library** tab to reuse an existing image instead of uploading a duplicate.",
+      "Fill in any alt text field to keep the site accessible.",
+    ],
+  },
+  {
+    title: "5. Reorder items",
+    body: [
+      "In repeatable collections you can drag entries by the handle to the left of each card.",
+      "Use the **Duplicate** option (three-dot menu in the top-right) to copy similar content and tweak it.",
+    ],
+  },
+  {
+    title: "6. Save, preview and publish",
+    body: [
+      "Hit **Save** to keep a draft for later.",
+      "Choose **Publish** once you are ready. This raises a pull request on GitHub with your update.",
+      "Cloudflare Pages builds a preview link automatically. Open it to double-check everything before approving the pull request.",
+    ],
+  },
+  {
+    title: "7. Need help?",
+    body: [
+      "Use the **Back to site** link in the CMS header to return to the public site.",
+      "Ask the development team if you need new fields added. They can update admin/config.yml to expose more content.",
+      "If the editor fails to load, sign out and back into GitHub, then refresh the page to re-authorise.",
+    ],
+  },
+];
+
+export default function EditorGuidePage() {
+  return (
+    <main className="bg-slate-950 py-16 text-slate-100">
+      <div className="mx-auto max-w-4xl px-6">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">
+          Content support
+        </p>
+        <h1 className="mt-3 text-4xl font-semibold sm:text-5xl">
+          How to update the website without touching code
+        </h1>
+        <p className="mt-4 text-lg text-slate-200">
+          The Cranbourne Food Truck site is fully editable through the Decap CMS interface at {" "}
+          <Link href="/admin" className="font-semibold text-rose-300 underline-offset-4 hover:underline">
+            /admin
+          </Link>
+          . Follow this checklist whenever you need to replace placeholder copy, upload new photos or refresh contact details.
+        </p>
+        <div className="mt-10 space-y-8">
+          {sections.map((section) => (
+            <section key={section.title} className="rounded-2xl border border-white/10 bg-white/5 p-6 shadow-lg backdrop-blur">
+              <h2 className="text-2xl font-semibold text-white">{section.title}</h2>
+              <ul className="mt-4 space-y-2 text-base text-slate-100">
+                {section.body.map((item) => (
+                  <li key={item} className="flex gap-3">
+                    <span className="mt-1.5 h-2 w-2 rounded-full bg-rose-300" aria-hidden="true" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        <p className="mt-12 text-sm text-slate-300">
+          Tip: bookmark this page or download the PDF version so future volunteers can self-serve updates without waiting on a developer.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/components/admin/AdminGuide.tsx
+++ b/components/admin/AdminGuide.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+
+const sections = [
+  {
+    title: "Open the editor",
+    steps: [
+      "Go to /admin on the live site. Sign in with your GitHub account when prompted.",
+      "After signing in the editor will load. The instructions below stay on this page in case you need a refresher.",
+    ],
+  },
+  {
+    title: "Choose what you want to update",
+    steps: [
+      "The left-hand sidebar lists every collection of content: Site Settings, Home Page, Team, Stories and so on.",
+      "Single entries such as the Home Page open directly; repeatable items like Team or Stories show an “Add new” button for creating additional cards.",
+    ],
+  },
+  {
+    title: "Edit text and links",
+    steps: [
+      "Click into any field and type the copy you want. Changes are saved as drafts until you publish.",
+      "Use the formatting toolbar on markdown fields (e.g. story body) for headings, bold, lists and links without needing to know Markdown syntax.",
+    ],
+  },
+  {
+    title: "Upload photos and logos",
+    steps: [
+      "Click the **Upload** button that appears next to any Image field.",
+      "Pick a file from your computer – PNG, JPG or SVG all work. The file is stored automatically in the site’s uploads folder and the preview updates instantly.",
+      "You can reuse an existing image by switching to the **Media Library** tab and selecting it.",
+    ],
+  },
+  {
+    title: "Preview and publish",
+    steps: [
+      "Hit **Save** to keep a draft or **Publish** to push the change live. Publishing creates a pull request on GitHub automatically.",
+      "Cloudflare Pages builds a preview of each change. Use the link shown after publishing to review before approving the pull request in GitHub.",
+    ],
+  },
+  {
+    title: "Need to make bulk updates?",
+    steps: [
+      "Repeatable content such as Team members and Partners lets you drag items to reorder them after saving.",
+      "If you want to copy an existing item, open it and use the **Duplicate** button in the top-right menu.",
+    ],
+  },
+];
+
+export function AdminGuide() {
+  return (
+    <section className="border-b border-white/10 bg-slate-950">
+      <div className="mx-auto max-w-5xl px-6 py-10 text-slate-100">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">
+          Need a refresher?
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold sm:text-4xl">
+          Edit the site without touching code
+        </h1>
+        <p className="mt-3 max-w-3xl text-base text-slate-200 sm:text-lg">
+          Everything on the public website comes from editable fields in the Decap CMS
+          (the panel that appears below). Follow the steps on this page whenever you
+          need to swap copy, add stories, or upload new logos and photos.
+        </p>
+        <p className="mt-4 text-sm text-slate-300">
+          Looking for a printable walkthrough? Download the {" "}
+          <Link
+            href="/editor-guide"
+            className="font-semibold text-rose-300 underline-offset-4 hover:underline"
+          >
+            content editor guide
+          </Link>
+          .
+        </p>
+        <div className="mt-8 grid gap-6 sm:grid-cols-2">
+          {sections.map((section) => (
+            <div
+              key={section.title}
+              className="rounded-xl border border-white/10 bg-white/5 p-6 shadow-lg backdrop-blur"
+            >
+              <h2 className="text-xl font-semibold text-white">{section.title}</h2>
+              <ol className="mt-3 space-y-2 text-sm text-slate-100">
+                {section.steps.map((step) => (
+                  <li key={step} className="flex gap-2">
+                    <span className="font-semibold text-rose-200">•</span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/docs/editor-guide.md
+++ b/docs/editor-guide.md
@@ -1,0 +1,47 @@
+# Cranbourne Food Truck – Content editor guide
+
+This walkthrough is written for volunteers who want to refresh real copy, photos and logos on the website without touching any code. Everything happens inside the Decap CMS editor that lives at `/admin`.
+
+## 1. Sign in
+
+1. Visit `https://<your-domain>/admin`.
+2. Click **Log in with GitHub** and authorise access. (Ask the site administrator to invite you if you do not yet have access.)
+3. The CMS loads inside the browser – no extra software is required.
+
+## 2. Pick something to edit
+
+- The left sidebar lists every editable section. Single pages such as **Home Page** or **Donate Page** open straight away.
+- Collections such as **Team**, **Stories** or **Partners** show existing entries. Use the **New** button to add another card.
+- Global details like logos, navigation, contact information and donation links live in **Site Settings**.
+
+## 3. Update copy
+
+- Click any field to start editing. Changes are saved as drafts until you press **Publish**.
+- Rich text areas offer buttons for headings, bold text, bullet lists, links and quotes.
+- You can undo with <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Z</kbd> just like a regular document editor.
+
+## 4. Add photos or logos
+
+1. Locate an **Image** field and choose **Upload**.
+2. Select a JPG, PNG or SVG from your computer. The CMS stores it inside `public/uploads/` for you.
+3. If the image is already in the library, switch to the **Media Library** tab and pick it instead of uploading a duplicate.
+4. Fill in the optional alt text field wherever it appears so the site stays accessible.
+
+## 5. Reorder items
+
+- Collections such as Team members allow drag-and-drop ordering. Grab the handle to the left of an entry inside the list view.
+- Use the **Duplicate** option (three dot menu in the top-right) to clone a similar entry and tweak the details.
+
+## 6. Save, preview and publish
+
+1. Choose **Save** if you want to leave a draft for someone else to review later.
+2. Choose **Publish** when you are ready. This creates a pull request on GitHub with your changes.
+3. Cloudflare Pages generates a deploy preview for each pull request. The link appears on the confirmation screen – open it to check everything looks correct before approving the PR in GitHub.
+
+## 7. Need help?
+
+- Use the **Back to site** link in the top left of the CMS to return to the live site at any time.
+- Ask the developer team if you need new collections or fields added; they can update `admin/config.yml` to expose them in the editor.
+- If the CMS fails to load, ensure you are logged into GitHub and reload the page. Persistent errors may mean the GitHub token has expired – re-authorise when prompted.
+
+Happy editing!


### PR DESCRIPTION
## Summary
- add an on-page admin guide so editors know how to update copy, images and logos from /admin
- publish a dedicated /editor-guide page with the same checklist and link to the printable docs/editor-guide.md file
- point the README to the new guide and clarify how to upload media from the CMS

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddfc7c434883319dff947e4b71aff4