### PR TITLE
Expose OAuth environment variables to the runtime

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,31 @@
 /** @type {import('next').NextConfig} */
+const runtimeEnvKeys = [
+  "GITHUB_CLIENT_ID",
+  "GITHUB_CLIENT_SECRET",
+  "DECAP_GITHUB_CLIENT_ID",
+  "DECAP_GITHUB_CLIENT_SECRET",
+  "DECAP_GITHUB_REPO",
+  "DECAP_GITHUB_APP_ID",
+  "DECAP_GITHUB_API_ROOT",
+  "DECAP_BACKEND_NAME",
+  "DECAP_BACKEND_BRANCH",
+  "DECAP_OAUTH_BASE_URL",
+  "DECAP_OAUTH_ENDPOINT",
+  "DECAP_SITE_URL",
+  "DECAP_DISPLAY_URL",
+  "OAUTH_BASE_URL",
+];
+
+const runtimeEnv = runtimeEnvKeys.reduce((acc, key) => {
+  acc[key] = process.env[key];
+  return acc;
+}, {});
+
 const nextConfig = {
   output: "standalone",
+  experimental: {
+    runtimeEnv,
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.ya?ml$/i,


### PR DESCRIPTION
## Summary
- ensure Next.js exposes the OAuth-related environment variables at runtime so the GitHub auth flow can read them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df1d119fcc83318029601323076c1e