### PR TITLE
Fix OAuth callback cookie deletion options

### DIFF
--- a/app/api/oauth/callback/route.ts
+++ b/app/api/oauth/callback/route.ts
@@ -59,6 +59,6 @@ export async function GET(req: Request) {
     path: "/",
     maxAge: 3600,
   });
-  res.cookies.delete("decap_oauth_state", { path: "/", secure: isSecure });
+  res.cookies.delete({ name: "decap_oauth_state", path: "/", secure: isSecure });
   return res;
 }


### PR DESCRIPTION
## Summary
- fix the OAuth callback handler to delete the state cookie using the supported options object

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df3179e57c8331ad53d0a7c72d891e