### PR TITLE
Expand OAuth env var fallbacks

### DIFF
--- a/ADMIN_SETUP.md
+++ b/ADMIN_SETUP.md
@@ -28,8 +28,8 @@ I've created a PowerShell script that sets the environment variables correctly. 
 
 **Option B: Set Environment Variables Manually**
 ```powershell
-$env:GITHUB_CLIENT_ID="5cb77d19ba008d68828300ed145ca9410ab0512a"
-$env:GITHUB_CLIENT_SECRET="Ov23lifXUhUiG4vCZHqd"
+$env:GITHUB_CLIENT_ID="Ov23lifXUhUiG4vCZHqd"
+$env:GITHUB_CLIENT_SECRET="5cb77d19ba008d68828300ed145ca9410ab0512a"
 $env:DECAP_GITHUB_REPO="ethanbaileyhomework/website-food-truck"
 $env:DECAP_BACKEND_BRANCH="main"
 $env:DECAP_OAUTH_BASE_URL="http://localhost:3000"

--- a/app/api/oauth/env.ts
+++ b/app/api/oauth/env.ts
@@ -13,9 +13,15 @@ const pickEnv = (...keys: (keyof NodeJS.ProcessEnv)[]) => {
 };
 
 export const getGitHubClientId = () =>
-  pickEnv("GITHUB_CLIENT_ID", "DECAP_GITHUB_CLIENT_ID");
+  pickEnv(
+    "GITHUB_CLIENT_ID",
+    "DECAP_GITHUB_CLIENT_ID",
+    "NEXT_PUBLIC_GITHUB_CLIENT_ID",
+    "NEXT_PUBLIC_DECAP_GITHUB_CLIENT_ID"
+  );
 
 export const getGitHubClientSecret = () =>
   pickEnv("GITHUB_CLIENT_SECRET", "DECAP_GITHUB_CLIENT_SECRET");
 
-export const getOAuthBaseUrl = () => pickEnv("OAUTH_BASE_URL");
+export const getOAuthBaseUrl = () =>
+  pickEnv("OAUTH_BASE_URL", "DECAP_OAUTH_BASE_URL");

--- a/start-dev.ps1
+++ b/start-dev.ps1
@@ -1,6 +1,6 @@
 # Set environment variables and start the development server
-$env:GITHUB_CLIENT_ID="5cb77d19ba008d68828300ed145ca9410ab0512a"
-$env:GITHUB_CLIENT_SECRET="Ov23lifXUhUiG4vCZHqd"
+$env:GITHUB_CLIENT_ID="Ov23lifXUhUiG4vCZHqd"
+$env:GITHUB_CLIENT_SECRET="5cb77d19ba008d68828300ed145ca9410ab0512a"
 $env:DECAP_GITHUB_REPO="ethanbaileyhomework/website-food-truck"
 $env:DECAP_BACKEND_BRANCH="main"
 $env:DECAP_OAUTH_BASE_URL="http://localhost:3000"


### PR DESCRIPTION
## Summary
- allow the GitHub OAuth route to read additional environment variable fallbacks for the client ID
- support the DECAP_OAUTH_BASE_URL override when constructing the OAuth redirect base

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df333cc71483319cd836906bfdf28b