### PR TITLE
Fix Decap OAuth redirect handling for custom endpoint configurations

### DIFF
--- a/app/api/oauth/env.ts
+++ b/app/api/oauth/env.ts
@@ -25,3 +25,6 @@ export const getGitHubClientSecret = () =>
 
 export const getOAuthBaseUrl = () =>
   pickEnv("OAUTH_BASE_URL", "DECAP_OAUTH_BASE_URL");
+
+export const getOAuthEndpoint = () =>
+  pickEnv("OAUTH_ENDPOINT", "DECAP_OAUTH_ENDPOINT");


### PR DESCRIPTION
## Summary
- allow the OAuth flow to respect the configured Decap auth endpoint when building callback URLs
- normalise endpoint values and fall back safely when the OAuth base URL is invalid
- expose the OAuth endpoint environment variables to the server runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df386ca1008331a63a9ce71fce3062