### PR TITLE
Add Cranbourne Food Truck logo asset

### DIFF
--- a/content/site-settings.yaml
+++ b/content/site-settings.yaml
@@ -1,6 +1,6 @@
 siteName: Cranbourne Food Truck
 siteTagline: Nourishing community with dignity and care.
-logo: ""
+logo: /images/logo-cft.svg
 primaryColor: "#C3423F"
 navigation:
   - label: "Home"

--- a/generated/content.json
+++ b/generated/content.json
@@ -2,7 +2,7 @@
   "siteSettings": {
     "siteName": "Cranbourne Food Truck",
     "siteTagline": "Nourishing community with dignity and care.",
-    "logo": "",
+    "logo": "/images/logo-cft.svg",
     "primaryColor": "#C3423F",
     "navigation": [
       {

--- a/public/content/site.json
+++ b/public/content/site.json
@@ -1,1 +1,1 @@
-{ "siteName": "Cranbourne Food Truck", "tagline": "", "primaryColor": "#0ea5e9", "logo": "" }
+{ "siteName": "Cranbourne Food Truck", "tagline": "", "primaryColor": "#0ea5e9", "logo": "/images/logo-cft.svg" }

--- a/public/images/logo-cft.svg
+++ b/public/images/logo-cft.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="plate" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0" stop-color="#F8F5F2" />
+      <stop offset="1" stop-color="#F1EAE4" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="32" fill="url(#plate)" />
+  <path
+    d="M56 54c0-13.255 10.745-24 24-24h0c13.255 0 24 10.745 24 24v24c0 13.255-10.745 24-24 24h0c-13.255 0-24-10.745-24-24V54Z"
+    fill="#C3423F"
+  />
+  <path
+    d="M52 112h56"
+    stroke="#2F2F2F"
+    stroke-width="10"
+    stroke-linecap="round"
+  />
+  <circle cx="68" cy="90" r="8" fill="#2F2F2F" />
+  <circle cx="100" cy="90" r="8" fill="#2F2F2F" />
+  <text
+    x="80"
+    y="140"
+    fill="#C3423F"
+    font-family="'Lato', 'Helvetica Neue', Arial, sans-serif"
+    font-size="36"
+    font-weight="700"
+    text-anchor="middle"
+  >Food Truck</text>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable Cranbourne Food Truck logo SVG asset for header usage
- wire the site settings logo references to the new asset so the header uses the artwork

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09f351c448331b832f1f12769a606